### PR TITLE
refactor(admin/questions): enhance pagination logic by syncing curren…

### DIFF
--- a/apps/frontend/src/app/(admin)/admin/questions/[id]/edit/page.tsx
+++ b/apps/frontend/src/app/(admin)/admin/questions/[id]/edit/page.tsx
@@ -5,12 +5,15 @@ import { toast } from '@/hooks/use-toast';
 import { getQuestionBySlug, updateQuestion } from '@/services/question.service';
 import { Question } from '@/types/typeAdmin';
 import { useQuery } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
-import React, {  useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation';
+import React, { Suspense,  useState } from 'react'
 
 const EditQuestion = ({ params }: { params: { id: string } }) => {
     const { id } = params;
     const [loading, setLoading] = useState(false);
+    const searchParams = useSearchParams();
+    const pageFromUrl = searchParams.get('page');
+    const backTo = pageFromUrl ? `/admin/questions?page=${pageFromUrl}` : '/admin/questions';
     const router = useRouter();
     const { data: question, isLoading, isError } = useQuery({
         queryKey: ["question", id],
@@ -20,7 +23,7 @@ const EditQuestion = ({ params }: { params: { id: string } }) => {
         staleTime: 5 * 60 * 1000,
     });
     if (!isLoading && !isError && !question) {
-        router.push("/admin/questions");
+        router.push(backTo);
         return null;
     }
 
@@ -47,7 +50,7 @@ const EditQuestion = ({ params }: { params: { id: string } }) => {
                 className: "bg-gray-100 text-gray-800",
               })
 
-            router.push("/admin/questions");
+            router.push(backTo);
 
         } catch (error) {
             toast({
@@ -65,13 +68,14 @@ const EditQuestion = ({ params }: { params: { id: string } }) => {
     };
 
     return (
+        <Suspense fallback={<Loading />}>
         <div>
                 {
                     !isLoading ? (
                         <QuestionForm
                             initialQuestion={question.data}
                             onSave={handleSave}
-                            onCancel={() => router.push('/admin/questions')}
+                            onCancel={() => router.push(backTo)}
                             loading={loading}
                         />
                     ) : (
@@ -79,6 +83,7 @@ const EditQuestion = ({ params }: { params: { id: string } }) => {
                     )
                 }
         </div>
+        </Suspense>
     )
 }
 

--- a/apps/frontend/src/app/(admin)/admin/questions/page.tsx
+++ b/apps/frontend/src/app/(admin)/admin/questions/page.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,  DialogDescription, DialogClose } from "@/components/ui/dialog";
 
 import { Button } from "@/components/ui/button";
@@ -142,6 +142,7 @@ export default function Tests() {
   
 
   return (
+    <Suspense fallback={<div className="flex items-center justify-center py-10 text-gray-500">Loading...</div>}>
     <>
       <div className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-2 sm:space-y-0">
         <div>
@@ -242,7 +243,7 @@ export default function Tests() {
                           <DropdownMenuContent align="end">
                             <DropdownMenuItem
                               className="flex items-center gap-2"
-                              onClick={() => router.push(`/admin/questions/${question.slug}/edit`)}
+                              onClick={() => router.push(`/admin/questions/${question.slug}/edit?page=${currentPage}`)}
                             >
                               <Edit className="h-4 w-4" /> Edit
                             </DropdownMenuItem>
@@ -291,7 +292,7 @@ export default function Tests() {
           <DropdownMenuItem 
             className="flex items-center gap-2"
             onClick={() => {
-              router.push(`/admin/questions/${contextMenu.question.slug}/edit`);
+              router.push(`/admin/questions/${contextMenu.question.slug}/edit?page=${currentPage}`);
               setContextMenu(null);
             }}
           >
@@ -316,6 +317,7 @@ export default function Tests() {
         </DialogContent>
       </Dialog>
     </>
+    </Suspense>
   )
 }
 

--- a/apps/frontend/src/app/(admin)/admin/questions/page.tsx
+++ b/apps/frontend/src/app/(admin)/admin/questions/page.tsx
@@ -33,7 +33,7 @@ import { toast } from "@/hooks/use-toast";
 import { QuestionType } from "@repo/db/enums";
 
 
-export default function Tests() {
+function QuestionsContent() {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [deleteQuestionSlug, setDeleteQuestionSlug] = useState(null);
   const router = useRouter()
@@ -77,6 +77,7 @@ export default function Tests() {
     if (normalized !== currentPage) {
       setCurrentPage(normalized);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
   
   
@@ -142,7 +143,6 @@ export default function Tests() {
   
 
   return (
-    <Suspense fallback={<div className="flex items-center justify-center py-10 text-gray-500">Loading...</div>}>
     <>
       <div className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-2 sm:space-y-0">
         <div>
@@ -317,6 +317,13 @@ export default function Tests() {
         </DialogContent>
       </Dialog>
     </>
+  )
+}
+
+export default function Tests() {
+  return (
+    <Suspense fallback={<div className="flex items-center justify-center py-10 text-gray-500">Loading...</div>}>
+      <QuestionsContent />
     </Suspense>
   )
 }


### PR DESCRIPTION
This pull request updates the pagination logic on the admin questions page to sync the current page state with the URL query parameters, ensuring that navigation and browser history work as expected. The changes improve user experience by maintaining page state consistency and enabling direct linking to specific pages.

**Pagination and URL synchronization:**

* The pagination state (`currentPage`) is now initialized from the `page` query parameter in the URL, and kept in sync with it using `useEffect`. This ensures that the correct page is shown when navigating or refreshing. [[1]](diffhunk://#diff-ccf129c2e9304d0b54fe5ed710e51599ae7a26d7033a70ab7b952c4a077a054eL40-R45) [[2]](diffhunk://#diff-ccf129c2e9304d0b54fe5ed710e51599ae7a26d7033a70ab7b952c4a077a054eR54-R81)
* Added helper functions (`updatePageInUrl` and `goToPage`) to update both the internal state and the URL when the page changes, supporting better navigation and allowing users to bookmark or share page-specific URLs.
* Updated the pagination button handlers to use the new `goToPage` function, ensuring both state and URL are updated when moving between pages.

**Routing and hooks:**

* Imported `usePathname` and `useSearchParams` from `next/navigation` to enable reading and updating the URL query parameters for pagination.
* Added `useEffect` to watch for changes in the URL’s `page` parameter and update the internal pagination state accordingly. [[1]](diffhunk://#diff-ccf129c2e9304d0b54fe5ed710e51599ae7a26d7033a70ab7b952c4a077a054eL2-R2) [[2]](diffhunk://#diff-ccf129c2e9304d0b54fe5ed710e51599ae7a26d7033a70ab7b952c4a077a054eR54-R81)…t page with URL parameters and improving navigation functions